### PR TITLE
Remove `@raw_expression` macro

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -84,8 +84,8 @@ state = @desmos begin
         b₅=B(a₄,b₄)
         a₆=A(a₅,b₅)
         b₆=B(a₅,b₅)
-        @raw_expression L"a = [a_{0},a_{1},a_{2},a_{3},a_{4},a_{5},a_{6}]"
-        @raw_expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
+        @expression L"a = [a_{0},a_{1},a_{2},a_{3},a_{4},a_{5},a_{6}]"
+        @expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
         (a₀,b₀)
         (a,b)
     end

--- a/src/Desmos.jl
+++ b/src/Desmos.jl
@@ -77,11 +77,15 @@ macro expression(ex, kwargs...)
             end
         end
     end
-    return DesmosExpression(eval(color), _latexify(ex))
-end
-
-macro raw_expression(ex)
-    return DesmosExpression(RGB(0,0,0), eval(ex))
+    if ex.head === :macrocall
+        if ex.args[1] === Symbol("@L_str")
+            DesmosExpression(eval(color), eval(ex))
+        else
+            error("Unsupported expression $(ex)")
+        end
+    else
+        return DesmosExpression(eval(color), _latexify(ex))
+    end
 end
 
 macro image(ex, kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,8 +77,8 @@ end
                 b₅=B(a₄,b₄)
                 a₆=A(a₅,b₅)
                 b₆=B(a₅,b₅)
-                @raw_expression L"a = [a_{0},a_{1},a_{2},a_{3},a_{4},a_{5},a_{6}]"
-                @raw_expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
+                @expression L"a = [a_{0},a_{1},a_{2},a_{3},a_{4},a_{5},a_{6}]"
+                @expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
                 (a₀,b₀)
                 (a,b)
             end


### PR DESCRIPTION
Now
```
@raw_expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
```
can be written as
```
@expression L"b = [b_{0},b_{1},b_{2},b_{3},b_{4},b_{5},b_{6}]"
```
